### PR TITLE
Fix resumo script output path

### DIFF
--- a/scripts/gerar_resumo_avioes.py
+++ b/scripts/gerar_resumo_avioes.py
@@ -56,7 +56,7 @@ avioes_json = {
 
 # Guardar para ficheiro JSON
 output_file = RESUMOS_DIR / "avioes.json"
-with open("output_file", "w", encoding="utf-8") as f:
+with open(output_file, "w", encoding="utf-8") as f:
     json.dump(avioes_json, f, ensure_ascii=False, indent=2)
 
 print(f"✅ Resumo gravado em: {output_file}")


### PR DESCRIPTION
## Summary
- fix the output path in `gerar_resumo_avioes.py`

## Testing
- `python3 -m py_compile scripts/*.py`
- `python3 scripts/gerar_resumo_avioes.py >/tmp/run.log && tail -n 20 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_6872976f68d8832ebdb96d8a23074bdd