### PR TITLE
Fix layout gap after map

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,7 @@
     <h1>SkyLog – Um olhar pousado no céu</h1>
   </header>
 
-<main class="painel">
+  <main class="painel">
 
     <!-- Última hora (coluna esquerda) -->
     <section id="ultima-hora">
@@ -20,22 +20,23 @@
       <ul id="ultima-hora-lista"></ul>
     </section>
 
-    <!-- Mapa -->
-    <section id="rotas">
-      <h2>Mapa de rotas</h2>
-      <canvas id="mapa">[Mapa de rotas]</canvas>
-    </section>
+    <!-- Coluna da direita: mapa + listas -->
+    <div id="painel-direita">
+      <section id="rotas">
+        <h2>Mapa de rotas</h2>
+        <canvas id="mapa">[Mapa de rotas]</canvas>
+      </section>
 
-    <!-- Coluna lateral à direita -->
-    <div id="coluna-lateral">
-      <div id="top-paises">
-        <h2>Top Países</h2>
-        <ul id="top-paises"></ul>
-      </div>
+      <div id="coluna-lateral">
+        <div id="top-paises">
+          <h2>Top Países</h2>
+          <ul id="top-paises-lista"></ul>
+        </div>
 
-      <div id="top-companhias">
-        <h2>Top Companhias</h2>
-        <ul id="top-companhias"></ul>
+        <div id="top-companhias">
+          <h2>Top Companhias</h2>
+          <ul id="top-companhias-lista"></ul>
+        </div>
       </div>
     </div>
 
@@ -60,13 +61,13 @@
         });
 
         // Top Países
-        const ulPaises = document.getElementById("top-paises").querySelector("ul");
+        const ulPaises = document.getElementById("top-paises-lista");
         dados.top_paises.forEach(p => {
           ulPaises.innerHTML += `<li>${p.bandeira || ""} ${p.pais}: ${p.total} aviões</li>`;
         });
 
         // Top Companhias
-        const ulCias = document.getElementById("top-companhias").querySelector("ul");
+        const ulCias = document.getElementById("top-companhias-lista");
         dados.top_companhias.forEach(c => {
           ulCias.innerHTML += `<li>${c.cia}: ${c.total} voos</li>`;
         });

--- a/site/style.css
+++ b/site/style.css
@@ -18,18 +18,21 @@ header h1 {
 /* Painel principal com grid */
 main.painel {
   display: grid;
-  grid-template-areas:
-    "ultima-hora rotas"
-    "ultima-hora coluna-lateral";
   grid-template-columns: 1fr 2fr;
-  grid-template-rows: min-content auto; /* Linha crucial! */
-  gap: 2rem;
-  align-items: start; /* Alinhar tudo pelo topo */
+  column-gap: 2rem; /* Espaço horizontal */
+  align-items: start; /* Alinhar pelo topo */
 }
 
-/* Última hora à esquerda (ocupa duas linhas) */
+/* Coluna direita empilha mapa e listas */
+#painel-direita {
+  display: grid;
+  grid-template-rows: min-content auto;
+  row-gap: 0; /* Sem espaço extra entre mapa e colunas */
+  align-items: start;
+}
+
+/* Última hora à esquerda */
 #ultima-hora {
-  grid-area: ultima-hora;
   border-left: 6px solid #2196f3;
   padding: 1.5rem;
   background: #fff;
@@ -41,7 +44,6 @@ main.painel {
 
 /* Mapa à direita no topo */
 #rotas {
-  grid-area: rotas;
   border-left: 6px solid #9c27b0;
   padding: 1.5rem;
   background: #fff;
@@ -61,7 +63,6 @@ main.painel {
 
 /* Coluna lateral (países + companhias) - agora fica abaixo do mapa */
 #coluna-lateral {
-  grid-area: coluna-lateral;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 2rem;


### PR DESCRIPTION
## Summary
- keep horizontal spacing but remove vertical gap below the map
- wrap the map and side lists in a dedicated column so row sizing isn't affected by the left pane

## Testing
- `python3 -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6872976f52cc832eb7bff9bfce342107