### PR TITLE
Add last hour summary panel

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -18,6 +18,11 @@
 
     <!-- Rankings à esquerda -->
     <div id="coluna-lateral">
+      <div id="painel-ultima-hora">
+        <h2>Na última hora</h2>
+        <p id="resumo-ultima-hora"></p>
+      </div>
+
       <div id="top-paises">
         <h2>Top Países</h2>
         <ul id="top-paises-lista"></ul>

--- a/site/scripts/painel.js
+++ b/site/scripts/painel.js
@@ -54,6 +54,42 @@ async function carregarPainel() {
       ulPaises.innerHTML += `<li>${p.bandeira || ""} <strong>${p.pais}</strong>: ${p.total} aviões</li>`;
     });
 
+    // resumo "Na última hora"
+    const resumoEl = document.getElementById("resumo-ultima-hora");
+    if (resumoEl) {
+      const total = dados.ultima_hora.length;
+      const paisesSet = new Set();
+      const ciasSet = new Set();
+      let maxDist = -Infinity;
+      let maxLoc = "";
+      let minDist = Infinity;
+      let minLoc = "";
+      let semLoc = 0;
+
+      dados.ultima_hora.forEach(v => {
+        if (v.pais) paisesSet.add(v.pais);
+        if (v.cia) ciasSet.add(v.cia);
+        const dist = parseFloat(v.dist);
+        if (isNaN(dist)) {
+          semLoc += 1;
+          return;
+        }
+        if (dist > maxDist) {
+          maxDist = dist;
+          maxLoc = v.local || "";
+        }
+        if (dist < minDist) {
+          minDist = dist;
+          minLoc = v.local || "";
+        }
+      });
+
+      resumoEl.textContent =
+        `Na última hora foram detetados ${total} aviões de ${paisesSet.size} países e ${ciasSet.size} companhias. ` +
+        `O avião mais distante estava a ${maxDist}km sobre ${capitalizar(maxLoc)} e o mais próximo a ${minDist}km, sobre ${capitalizar(minLoc)}. ` +
+        `Entre estes avistamentos, houve ${semLoc} aviões que não partilharam a sua localização.`;
+    }
+
     const ulCias = document.getElementById("top-companhias-lista");
     dados.top_companhias.forEach(c => {
       ulCias.innerHTML += `<li><strong>${c.cia}</strong>: ${c.total} voos</li>`;

--- a/site/styles/style.css
+++ b/site/styles/style.css
@@ -85,6 +85,7 @@ main.painel {
 }
 
 /* Bordas coloridas para cada painel lateral */
+#painel-ultima-hora { border-left: 6px solid #03a9f4; }
 #top-paises { border-left: 6px solid #4caf50; }
 #top-companhias { border-left: 6px solid #ff9800; }
 


### PR DESCRIPTION
## Summary
- place last hour summary in its own panel above the rankings
- style new panel with blue border

## Testing
- `python3 -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6873736362f4832e976b562bf1c57bdf