### PR TITLE
Rotate plane icons to match route direction

### DIFF
--- a/site/scripts/painel.js
+++ b/site/scripts/painel.js
@@ -101,14 +101,24 @@ async function carregarPainel() {
       attribution: "© OpenStreetMap"
     }).addTo(map);
 
-    const planeIcon = L.divIcon({ className: "plane-icon", html: "✈️", iconSize: [20,20], iconAnchor: [10,10] });
+    const planeIcon = L.divIcon({
+      className: "plane-icon",
+      html: "✈️",
+      iconSize: [20, 20],
+      iconAnchor: [10, 10]
+    });
 
     dados.rotas.forEach(r => {
       if (!r.de || !r.para) return;
       const ini = [r.de[0], r.de[1]];
       const fim = [r.para[0], r.para[1]];
       L.polyline([ini, fim], { color: "red", weight: 2 }).addTo(map);
-      L.marker(fim, { icon: planeIcon }).addTo(map);
+      const marker = L.marker(fim, { icon: planeIcon }).addTo(map);
+      const ang = (Math.atan2(fim[0] - ini[0], fim[1] - ini[1]) * 180) / Math.PI;
+      const el = marker.getElement();
+      if (el) {
+        el.style.transform += ` rotate(${ang}deg)`;
+      }
     });
   } catch (e) {
     console.error("Erro ao carregar painel:", e);

--- a/site/styles/style.css
+++ b/site/styles/style.css
@@ -66,6 +66,7 @@ main.painel {
 
 .plane-icon {
   font-size: 20px;
+  transform-origin: center;
 }
 
 /* Coluna lateral (países + companhias) - agora fica abaixo do mapa */


### PR DESCRIPTION
## Summary
- rotate plane icons based on route direction
- ensure rotation origin is centered

## Testing
- `python3 scripts/preparar_site.py`

------
https://chatgpt.com/codex/tasks/task_e_687379f9dbf4832eaa838a3b96ccacf7