### PR TITLE
Color routes by direction

### DIFF
--- a/scripts/preparar_site.py
+++ b/scripts/preparar_site.py
@@ -183,8 +183,15 @@ for reg in registos:
     pos = rotas_raw.get(vid)
     if not pos:
         continue
-    rota = {"hex": reg["hex"], "chamada": reg["chamada"],
-            "de": pos.get("de"), "para": pos.get("para")}
+    rota = {
+        "hex": reg["hex"],
+        "chamada": reg["chamada"],
+        "de": pos.get("de"),
+        "para": pos.get("para"),
+    }
+    alt = reg.get("alt")
+    if alt:
+        rota["alt"] = alt
     rotas.append(rota)
 
 saida = {

--- a/site/scripts/painel.js
+++ b/site/scripts/painel.js
@@ -1,3 +1,4 @@
+
 async function carregarPainel() {
   try {
     const resp = await fetch("painel.json");
@@ -19,6 +20,16 @@ async function carregarPainel() {
             .join("-")
         )
         .join(" ");
+    }
+
+    function calcBearing(lat1, lon1, lat2, lon2) {
+      const toRad = d => (d * Math.PI) / 180;
+      const dLon = toRad(lon2 - lon1);
+      const y = Math.sin(dLon) * Math.cos(toRad(lat2));
+      const x =
+        Math.cos(toRad(lat1)) * Math.sin(toRad(lat2)) -
+        Math.sin(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(dLon);
+      return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
     }
 
     const ulHora = document.getElementById("ultima-hora-lista");
@@ -95,20 +106,57 @@ async function carregarPainel() {
       ulCias.innerHTML += `<li><strong>${c.cia}</strong>: ${c.total} voos</li>`;
     });
 
-    const map = L.map("mapa").setView([39.7078, -8.0570], 8);
-    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    const initialZoom = 8;
+    const map = L.map("mapa", {
+      dragging: false,
+      minZoom: initialZoom,
       maxZoom: 18,
+      touchZoom: "center",
+    }).setView([39.7078, -8.0570], initialZoom);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
       attribution: "© OpenStreetMap"
     }).addTo(map);
 
-    const planeIcon = L.divIcon({ className: "plane-icon", html: "✈️", iconSize: [20,20], iconAnchor: [10,10] });
+    function destPoint(lat, lon, brng, distKm) {
+      const R = 6371;
+      const toRad = d => (d * Math.PI) / 180;
+      const toDeg = d => (d * 180) / Math.PI;
+      const b = toRad(brng);
+      const d = distKm / R;
+      const lat1 = toRad(lat);
+      const lon1 = toRad(lon);
+      const lat2 = Math.asin(
+        Math.sin(lat1) * Math.cos(d) + Math.cos(lat1) * Math.sin(d) * Math.cos(b)
+      );
+      const lon2 =
+        lon1 +
+        Math.atan2(
+          Math.sin(b) * Math.sin(d) * Math.cos(lat1),
+          Math.cos(d) - Math.sin(lat1) * Math.sin(lat2)
+        );
+      return [toDeg(lat2), toDeg(lon2)];
+    }
+
+    function directionColor(bearing) {
+      const h = ((bearing % 360) + 360) % 360;
+      return `hsl(${h}, 80%, 45%)`;
+    }
+
+    function desenharSeta(inicio, fim, bearing, cor) {
+      L.polyline([inicio, fim], { color: cor, weight: 2 }).addTo(map);
+      const len = 5; // arrowhead length in km
+      const left = destPoint(fim[0], fim[1], bearing + 210, len);
+      const right = destPoint(fim[0], fim[1], bearing + 150, len);
+      L.polygon([left, fim, right], { color: cor, fillColor: cor, weight: 1 }).addTo(map);
+    }
 
     dados.rotas.forEach(r => {
       if (!r.de || !r.para) return;
       const ini = [r.de[0], r.de[1]];
       const fim = [r.para[0], r.para[1]];
-      L.polyline([ini, fim], { color: "red", weight: 2 }).addTo(map);
-      L.marker(fim, { icon: planeIcon }).addTo(map);
+      const bearing = calcBearing(ini[0], ini[1], fim[0], fim[1]);
+      const cor = directionColor(bearing);
+      desenharSeta(ini, fim, bearing, cor);
     });
   } catch (e) {
     console.error("Erro ao carregar painel:", e);

--- a/site/styles/style.css
+++ b/site/styles/style.css
@@ -64,9 +64,6 @@ main.painel {
   border-radius: 6px;
 }
 
-.plane-icon {
-  font-size: 20px;
-}
 
 /* Coluna lateral (países + companhias) - agora fica abaixo do mapa */
 #coluna-lateral {


### PR DESCRIPTION
## Summary
- make the arrowhead a small filled triangle
- color the route lines according to the flight direction instead of altitude
- keep the map fixed on load allowing only zoom in

## Testing
- `python3 scripts/preparar_site.py`


------
https://chatgpt.com/codex/tasks/task_e_687379f9dbf4832eaa838a3b96ccacf7