### PR TITLE
Corrigir hora local ao registar ADS-B

### DIFF
--- a/scripts/captura_adsb.py
+++ b/scripts/captura_adsb.py
@@ -21,7 +21,9 @@ try:
         text=True
     )
     data = json.loads(resultado.stdout)
-    now = datetime.utcfromtimestamp(data["now"])
+    # O timestamp fornecido pelo dump1090 está em UTC. Convertemos para a
+    # hora local para que os ficheiros sejam gravados com a hora correta.
+    now = datetime.fromtimestamp(data["now"])
 except Exception as e:
     print(f"❌ Erro ao obter dados do dump1090 via curl: {e}")
     exit(1)
@@ -75,6 +77,6 @@ for aviao in data.get("aircraft", []):
     guardar(daily_file, registo, campos)
     contagem += 1
 
-print(f"✅ {contagem} aviões gravados às {now.strftime('%H:%M')} UTC")
+print(f"✅ {contagem} aviões gravados às {now.strftime('%H:%M')} (hora local)")
 print(f"↪ Ficheiro horário: {hourly_file}")
 print(f"↪ Ficheiro diário : {daily_file}")


### PR DESCRIPTION
## Summary
- converter timestamp do dump1090 para hora local em `captura_adsb.py`
- atualizar mensagem de log para indicar hora local

## Testing
- `python3 -m py_compile scripts/captura_adsb.py`

------
https://chatgpt.com/codex/tasks/task_e_687390e5dfe8832eaabf9a7b3faa6309