### PR TITLE
Corrigir hora local ao preparar o site

### DIFF
--- a/docs/scripts/painel.js
+++ b/docs/scripts/painel.js
@@ -34,16 +34,7 @@ async function carregarPainel() {
 
     const ulHora = document.getElementById("ultima-hora-lista");
     dados.ultima_hora.forEach(v => {
-      const dt = new Date(v.hora + "Z");
-      const opt = {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-        timeZone: "Europe/Lisbon",
-      };
-      const hm = new Intl.DateTimeFormat("pt-PT", opt)
-        .format(dt)
-        .replace(":", "h") + "m";
+      const hm = v.hora.slice(11, 16).replace(":", "h") + "m";
 
       const altM = v.alt ? Math.round(parseFloat(v.alt) * 0.3048) : null;
       const velK = v.vel ? Math.round(parseFloat(v.vel) * 1.852) : null;
@@ -95,14 +86,8 @@ async function carregarPainel() {
         }
       });
 
-      const horaRef = new Date(dados.ultima_hora[0].hora + "Z");
-      const h = new Intl.DateTimeFormat("pt-PT", {
-        hour: "2-digit",
-        hour12: false,
-        timeZone: "Europe/Lisbon",
-      })
-        .format(horaRef)
-        .padStart(2, "0");
+      const horaRef = dados.ultima_hora[0].hora.slice(11, 13);
+      const h = horaRef.padStart(2, "0");
       const prox = String((parseInt(h, 10) + 1) % 24).padStart(2, "0");
 
       resumoEl.textContent =

--- a/scripts/captura_adsb.py
+++ b/scripts/captura_adsb.py
@@ -21,7 +21,9 @@ try:
         text=True
     )
     data = json.loads(resultado.stdout)
-    now = datetime.utcfromtimestamp(data["now"])
+    # O timestamp fornecido pelo dump1090 está em UTC. Convertemos para a
+    # hora local para que os ficheiros sejam gravados com a hora correta.
+    now = datetime.fromtimestamp(data["now"])
 except Exception as e:
     print(f"❌ Erro ao obter dados do dump1090 via curl: {e}")
     exit(1)
@@ -75,6 +77,6 @@ for aviao in data.get("aircraft", []):
     guardar(daily_file, registo, campos)
     contagem += 1
 
-print(f"✅ {contagem} aviões gravados às {now.strftime('%H:%M')} UTC")
+print(f"✅ {contagem} aviões gravados às {now.strftime('%H:%M')} (hora local)")
 print(f"↪ Ficheiro horário: {hourly_file}")
 print(f"↪ Ficheiro diário : {daily_file}")


### PR DESCRIPTION
## Summary
- adaptar painel.js para usar a hora gravada sem conversão

## Testing
- `python3 -m py_compile scripts/preparar_site.py`
- `python3 -m py_compile scripts/captura_adsb.py`


------
https://chatgpt.com/codex/tasks/task_e_687390e5dfe8832eaabf9a7b3faa6309