### PR TITLE
Fix spacing when columns stack

### DIFF
--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -20,6 +20,7 @@ main.painel {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr; /* colunas com a mesma largura */
   column-gap: 2rem; /* Espaço horizontal */
+  row-gap: 2rem; /* Espaço vertical para quando empilha */
   align-items: start; /* Alinhar pelo topo */
 }
 


### PR DESCRIPTION
## Summary
- add row-gap to `.painel` grid so stacked columns have spacing on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873ce47a6fc832eb579691488496c1f