### PR TITLE
Switch captura_adsb to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ web panel showing the latest detections. The raw CSV logs are kept under the
 ## Requirements
 
 - Python 3.8 or newer
-- `curl` available in the system PATH
 - A running `dump1090` server reachable at `http://localhost:8080`
 - Install Python dependencies with `pip install -r requirements.txt`
 
@@ -37,17 +36,15 @@ BASE_DIR=/path/to/dir python3 scripts/captura_adsb.py
 ```
 This command is run every minute via cron to capture new aircraft data.
 
-Lines in the script show it directly calls `curl` and stores the files:
+The script uses the `requests` library to fetch the JSON data:
 ```python
 root_dir = Path(os.environ.get("BASE_DIR", Path(__file__).resolve().parent.parent))
 base_dir = root_dir / "dados"
 HOURLY_DIR = base_dir / "horarios"
 DAILY_DIR  = base_dir / "diarios"
-# Executar curl para obter o JSON diretamente
-resultado = subprocess.run(
-    ["curl", "-s", "http://localhost:8080/data/aircraft.json"],
-    check=True, capture_output=True, text=True,
-)
+resposta = requests.get("http://localhost:8080/data/aircraft.json", timeout=5)
+resposta.raise_for_status()
+data = resposta.json()
 ```
 
 ### gerar_companhias.py

--- a/scripts/captura_adsb.py
+++ b/scripts/captura_adsb.py
@@ -2,7 +2,7 @@
 import os
 import csv
 import json
-import subprocess
+import requests
 from datetime import datetime
 from pathlib import Path
 
@@ -16,20 +16,18 @@ def main() -> None:
     hourly_dir.mkdir(parents=True, exist_ok=True)
     daily_dir.mkdir(parents=True, exist_ok=True)
 
-    # Executar curl para obter o JSON diretamente
+    # Obter o JSON diretamente via requests
     try:
-        resultado = subprocess.run(
-            ["curl", "-s", "http://localhost:8080/data/aircraft.json"],
-            check=True,
-            capture_output=True,
-            text=True,
+        resposta = requests.get(
+            "http://localhost:8080/data/aircraft.json", timeout=5
         )
-        data = json.loads(resultado.stdout)
+        resposta.raise_for_status()
+        data = resposta.json()
         # O timestamp fornecido pelo dump1090 está em UTC. Convertemos para a
         # hora local para que os ficheiros sejam gravados com a hora correta.
         now = datetime.fromtimestamp(data["now"])
     except Exception as e:
-        print(f"❌ Erro ao obter dados do dump1090 via curl: {e}")
+        print(f"❌ Erro ao obter dados do dump1090: {e}")
         return
 
     # Verificar se há aviões


### PR DESCRIPTION
## Summary
- fetch ADS-B data using the requests library
- update README instructions to remove curl and show requests usage

## Testing
- `python3 -m py_compile scripts/*.py`
- `python3 scripts/captura_adsb.py` *(fails to connect but handled gracefully)*

------
https://chatgpt.com/codex/tasks/task_e_6873eb1ff548832eab9edc09d97836a9