### PR TITLE
Fix duplicate UAE entry

### DIFF
--- a/dados/companhias.json
+++ b/dados/companhias.json
@@ -330,9 +330,6 @@
     "nome": "Solairus Aviation"
   },
   "UAE": {
-    "nome": "UAE"
-  },
-  "UAE": {
     "nome": "United Airlines"
   },
   "UAL": {


### PR DESCRIPTION
## Summary
- remove duplicate `UAE` entry from `dados/companhias.json`
- keep one entry that maps `UAE` to "United Airlines"
- add final newline

## Testing
- `jq . dados/companhias.json`

------
https://chatgpt.com/codex/tasks/task_e_6873f15bf894832e9d8ac899649ada1f