### PR TITLE
Update companhias generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,6 @@ resposta.raise_for_status()
 data = resposta.json()
 ```
 
-### gerar_companhias.py
-Parses the hourly CSV files and builds `dados/companhias.json` with a simple
-mapping of callsign prefixes to airline names.
-
-```bash
-python3 scripts/gerar_companhias.py
-```
-
 ### gerar_resumo_avioes.py
 Aggregates all daily CSV logs and stores a summary in
 `resumos/avioes.json`.
@@ -101,8 +93,7 @@ This script is triggered hourly via cron to publish the updated site.
 
 1. Run `captura_adsb.py` periodically to gather new data. This repository uses
    a cron job to execute it every minute.
-2. Optionally run `gerar_companhias.py` and `gerar_resumo_avioes.py` to refresh
-   the auxiliary JSON files.
+2. Optionally run `gerar_resumo_avioes.py` to refresh the auxiliary JSON files.
 3. Run `preparar_site.py` to create `docs/painel.json`.
 4. Serve the contents of the `docs/` directory with any static web server or
    push them to GitHub Pages. The `publicar_site.sh` script, executed hourly via

--- a/scripts/gerar_companhias.py
+++ b/scripts/gerar_companhias.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import os
 import csv
 import json
-from collections import Counter
 
 
 def main() -> None:
@@ -13,8 +12,16 @@ def main() -> None:
     csv_dir = base_dir / "dados" / "horarios"
     saida = base_dir / "dados" / "companhias.json"
 
-    companhias = Counter()
+    # Carregar mapeamentos existentes, se houver
+    existentes = {}
+    if saida.exists():
+        try:
+            with saida.open(encoding="utf-8") as f:
+                existentes = json.load(f)
+        except Exception:
+            pass
 
+    codigos = set()
     for ficheiro in csv_dir.glob("*.csv"):
         with ficheiro.open(encoding="utf-8") as f:
             leitor = csv.DictReader(f)
@@ -22,13 +29,17 @@ def main() -> None:
                 voo = linha.get("flight", "").strip()
                 if len(voo) >= 3 and voo[:3].isalpha():
                     codigo = voo[:3].upper()
-                    companhias[codigo] += 1
+                    codigos.add(codigo)
 
-    # Ordenar alfabeticamente os códigos
-    resultado = {codigo: {"nome": codigo} for codigo in sorted(companhias)}
+    # Combinar com os mapeamentos existentes e manter nomes conhecidos
+    resultado = {}
+    todos = codigos | set(existentes.keys())
+    for codigo in sorted(todos):
+        nome = existentes.get(codigo, {}).get("nome", codigo)
+        resultado[codigo] = {"nome": nome}
 
     saida.write_text(json.dumps(resultado, indent=2, ensure_ascii=False))
-    print(f"Ficheiro gerado: {saida}")
+    print(f"Ficheiro atualizado: {saida}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- maintain existing airline names when generating `companhias.json`
- simplify docs by dropping unused `gerar_companhias.py` references

## Testing
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6873f289f760832e86ab10df2111d1d4