### PR TITLE
Fix ADS‑B capture with curl again

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ web panel showing the latest detections. The raw CSV logs are kept under the
 ## Requirements
 
 - Python 3.8 or newer
+- `curl` available in the system PATH
 - A running `dump1090` server reachable at `http://localhost:8080` (or set
   `DUMP1090_URL` to a custom endpoint)
 
@@ -48,8 +49,8 @@ BASE_DIR=/path/to/dir python3 scripts/captura_adsb.py
 ```
 This command is run every minute via cron to capture new aircraft data.
 
-The script uses the `requests` library to fetch the JSON data. You can override
-the default URL with the `DUMP1090_URL` environment variable:
+The script uses `curl` to fetch the JSON data. You can override the default URL
+with the `DUMP1090_URL` environment variable:
 
 ```python
 root_dir = Path(os.environ.get("BASE_DIR", Path(__file__).resolve().parent.parent))
@@ -57,16 +58,11 @@ base_dir = root_dir / "dados"
 HOURLY_DIR = base_dir / "horarios"
 DAILY_DIR  = base_dir / "diarios"
 url = os.environ.get("DUMP1090_URL", "http://localhost:8080/data/aircraft.json")
-session = requests.Session()
-session.trust_env = False
-resposta = session.get(
-    url,
-    timeout=5,
-    headers={"User-Agent": "SkyLog/1.0"},
+resultado = subprocess.run(
+    ["curl", "-sS", "--fail", "--noproxy", "*", url],
+    check=True, capture_output=True, text=True,
 )
-
-resposta.raise_for_status()
-data = resposta.json()
+data = json.loads(resultado.stdout)
 ```
 
 ### gerar_companhias.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-requests


### PR DESCRIPTION
## Summary
- revert captura_adsb.py to use `curl` instead of `requests`
- remove `requests` dependency
- document curl usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ff56b934832e9dace655f86ddc44