### PR TITLE
Add time filter menu

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,14 @@
 
   <header>
     <h1>SkyLog – Um olhar pousado no céu</h1>
+    <nav id="menu-tempo">
+      <button>Hora</button>
+      <button>Dia</button>
+      <button>Semana</button>
+      <button>Mês</button>
+      <button>Ano</button>
+      <button>Global</button>
+    </nav>
   </header>
 
   <main class="painel">

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -15,6 +15,30 @@ header h1 {
   font-size: 2.2rem;
 }
 
+/* Menu temporal abaixo do título */
+#menu-tempo {
+  display: flex;
+  justify-content: center;
+  gap: 0.8rem;
+  margin-top: -1rem;
+  margin-bottom: 2rem;
+}
+
+#menu-tempo button {
+  background: #0288d1;
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s ease;
+}
+
+#menu-tempo button:hover {
+  background: #0277bd;
+}
+
 /* Painel principal com grid */
 main.painel {
   display: grid;


### PR DESCRIPTION
## Summary
- add a new temporal menu under the page title
- style the menu with modern buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68741dbfc454832ea47d97082e1ada9f