### PR TITLE
Update live radar page to match main style

### DIFF
--- a/docs/live/index.html
+++ b/docs/live/index.html
@@ -2,13 +2,28 @@
 <html lang="pt">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>SkyLog - Radar Aéreo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SkyLog - Radar Aéreo ao Vivo</title>
+  <link rel="stylesheet" href="../styles/style.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="map"></div>
+  <header>
+    <h1>SkyLog – Radar Aéreo ao Vivo</h1>
+  </header>
+
+  <main class="painel">
+    <section id="rotas">
+      <h2>Mapa em Tempo Real</h2>
+      <div id="mapa"></div>
+    </section>
+
+    <section id="ultima-hora">
+      <h2>Aeronaves Ativas</h2>
+      <ul id="lista-avioes"></ul>
+    </section>
+  </main>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="script.js"></script>

--- a/docs/live/script.js
+++ b/docs/live/script.js
@@ -1,6 +1,6 @@
 const API_URL = "https://share-physics-gulf-changing.trycloudflare.com/dados";
 
-const map = L.map('map').setView([39.5, -8.0], 7); // centro de Portugal
+const map = L.map('mapa').setView([39.5, -8.0], 7); // centro de Portugal
 
 L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© OpenStreetMap',
@@ -9,6 +9,7 @@ L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 let aircraftMarkers = {};
 let rastosPorAeronave = {};
 let linhasRasto = {};
+const listaAvioes = document.getElementById('lista-avioes');
 
 
 // Aplica uma cor à imagem branca com contorno, usando CSS filter
@@ -76,6 +77,7 @@ function fetchAircraft() {
       const seenThreshold = now - 60; // mostrar apenas aviões recentes
 
       const novos = {};
+      listaAvioes.innerHTML = "";
 
       (data.aircraft || []).forEach(ac => {
         if (!ac.lat || !ac.lon || ac.seen > 60) return;
@@ -98,6 +100,7 @@ function fetchAircraft() {
         }
 
         novos[key] = true; // marca como ainda ativo
+        listaAvioes.innerHTML += `<li><strong>${info}</strong> – ${altitude} ft</li>`;
       });
 
       // Remove os que já não estão ativos

--- a/docs/live/style.css
+++ b/docs/live/style.css
@@ -1,13 +1,4 @@
-html, body {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-}
-
-#map {
-  height: 100%;
-  width: 100%;
-}
+/* Ajustes específicos da página ao vivo */
 
 /* Ícones de avião como divIcon */
 .plane-icon {


### PR DESCRIPTION
## Summary
- align `docs/live` page with the main site layout
- reuse shared CSS and list active aircraft in a sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687502699504832e8beba206bb20d709