### PR TITLE
Add hour archive navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,6 +28,10 @@
 
     <!-- Rankings à esquerda -->
     <div id="coluna-lateral">
+      <nav id="navegacao-horas">
+        <button id="hora-anterior">Hora anterior</button>
+        <button id="hora-seguinte">Hora seguinte</button>
+      </nav>
       <div id="painel-ultima-hora">
         <h2>Na última hora</h2>
         <p id="resumo-ultima-hora"></p>

--- a/docs/scripts/painel.js
+++ b/docs/scripts/painel.js
@@ -1,7 +1,11 @@
 
 async function carregarPainel() {
   try {
-    const resp = await fetch("hora_corrente.json");
+    const params = new URLSearchParams(window.location.search);
+    const horaParam = params.get("h");
+    const ficheiro = horaParam ? `arquivo/${horaParam}.json` : "hora_corrente.json";
+    const resp = await fetch(ficheiro);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const dados = await resp.json();
 
     const bandeiras = {};
@@ -30,6 +34,31 @@ async function carregarPainel() {
         Math.cos(toRad(lat1)) * Math.sin(toRad(lat2)) -
         Math.sin(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(dLon);
       return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+    }
+
+    function formatLabel(date) {
+      return date.toISOString().slice(0, 13).replace("T", "_");
+    }
+
+    const baseStr = horaParam || formatLabel(new Date(dados.ultima_hora[0].hora));
+    const baseDate = new Date(baseStr.replace("_", "T") + ":00");
+    const prevLabel = formatLabel(new Date(baseDate.getTime() - 3600 * 1000));
+    const nextLabel = formatLabel(new Date(baseDate.getTime() + 3600 * 1000));
+
+    const btnPrev = document.getElementById("hora-anterior");
+    if (btnPrev) btnPrev.onclick = () => {
+      window.location.search = "?h=" + prevLabel;
+    };
+
+    const btnNext = document.getElementById("hora-seguinte");
+    if (btnNext) {
+      if (horaParam) {
+        btnNext.onclick = () => {
+          window.location.search = "?h=" + nextLabel;
+        };
+      } else {
+        btnNext.disabled = true;
+      }
     }
 
     const ulHora = document.getElementById("ultima-hora-lista");

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -39,6 +39,34 @@ header h1 {
   background: #0277bd;
 }
 
+/* Navegação entre horas */
+#navegacao-horas {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+#navegacao-horas button {
+  background: #0288d1;
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s ease;
+}
+
+#navegacao-horas button:hover {
+  background: #0277bd;
+}
+
+#navegacao-horas button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Painel principal com grid */
 main.painel {
   display: grid;


### PR DESCRIPTION
## Summary
- add hour navigation menu to the sidebar
- style the new navigation buttons
- support loading specific hour archives in `painel.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687546eba7dc832ebf64606afd4ecc7f