### PR TITLE
Fix live page layout and navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,13 +15,13 @@
   <header>
     <h1>SkyLog - Um olhar pousado no céu</h1>
     <nav id="menu-tempo">
-      <button>Hora</button>
+      <a href="index.html">Hora</a>
       <button>Dia</button>
       <button>Semana</button>
       <button>Mês</button>
       <button>Ano</button>
       <button>Global</button>
-      <button>Ao vivo</button>
+      <a href="live.html">Ao vivo</a>
     </nav>
   </header>
 

--- a/docs/live.html
+++ b/docs/live.html
@@ -13,28 +13,28 @@
   <header>
     <h1>SkyLog - Um olhar pousado no céu</h1>
     <nav id="menu-tempo">
-      <button>Hora</button>
+      <a href="index.html">Hora</a>
       <button>Dia</button>
       <button>Semana</button>
       <button>Mês</button>
       <button>Ano</button>
       <button>Global</button>
-      <button>Ao vivo</button>
+      <a href="live.html">Ao vivo</a>
     </nav>
   </header>
 
   <main class="painel">
 
         <div id="coluna-lateral">
-
-      <div id="painel-ultima-hora">
-        <h2>Neste momento</h2>
-        <p>Esta página representa a atividade de aviões detatados neste momento...
-        <p>To do.</p>
-        </p>
+        <div id="painel-ultima-hora">
+          <h2>Neste momento</h2>
+          <p>Esta página representa a atividade de aviões detetados neste momento.</p>
+          <p>To do.</p>
       </div>
 
-    <section id="rotas">
+      </div>
+
+      <section id="rotas">
       <h2>Mapa em Tempo Real</h2>
       <div id="mapa"></div>
     </section>

--- a/docs/scripts/painel.js
+++ b/docs/scripts/painel.js
@@ -143,7 +143,7 @@ async function carregarPainel() {
       const h = horaRef.padStart(2, "0");
       const prox = String((parseInt(h, 10) + 2) % 24).padStart(2, "0");
 
-      resumoEl.textContent =
+      resumoEl.innerHTML =
         `Entre as <strong> ${h}h00m </strong> e as <strong> ${h}h59m </strong> foram detetadas ${total} aeronaves de ${paisesSet.size} países e ${ciasSet.size} companhias. ` +
         `A mais distante estava a ${maxDist}km sobre ${capitalizar(maxLoc)} e a mais próxima a ${minDist}km, sobre ${capitalizar(minLoc)}. ` +
         `Entre estes avistamentos, houve ${semLoc} aeronaves que não partilharam a sua localização. ` +

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -24,7 +24,8 @@ header h1 {
   margin-bottom: 2rem;
 }
 
-#menu-tempo button {
+#menu-tempo button,
+#menu-tempo a {
   background: #0288d1;
   color: #fff;
   border: none;
@@ -35,7 +36,8 @@ header h1 {
   transition: background 0.2s ease;
 }
 
-#menu-tempo button:hover {
+#menu-tempo button:hover,
+#menu-tempo a:hover {
   background: #0277bd;
 }
 


### PR DESCRIPTION
## Summary
- fix navbar links so 'Hora' and 'Ao vivo' navigate between pages
- correct HTML structure of **live.html** to enable three-column layout
- allow `<strong>` tags in the "Nesta hora" section by using `innerHTML`
- apply navbar button styling to anchors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757bd30040832ea7f6ff8fa22618d8