### PR TITLE
Refatora menu principal

### DIFF
--- a/docs/header.html
+++ b/docs/header.html
@@ -1,0 +1,12 @@
+<header>
+  <h1>SkyLog - Um olhar pousado no céu</h1>
+  <nav id="menu-tempo">
+    <a href="index.html">Ao vivo</a>
+    <a href="hora.html">Hora</a>
+    <button>Dia</button>
+    <button>Semana</button>
+    <button>Mês</button>
+    <button>Ano</button>
+    <button>Global</button>
+  </nav>
+</header>

--- a/docs/hora.html
+++ b/docs/hora.html
@@ -12,18 +12,7 @@
 </head>
 <body>
 
-  <header>
-    <h1>SkyLog - Um olhar pousado no céu</h1>
-    <nav id="menu-tempo">
-      <a href="index.html">Ao vivo</a>
-      <a href="hora.html">Hora</a>
-      <button>Dia</button>
-      <button>Semana</button>
-      <button>Mês</button>
-      <button>Ano</button>
-      <button>Global</button>
-    </nav>
-  </header>
+  <div data-include-html="header.html"></div>
 
   <main class="painel">
 
@@ -63,6 +52,7 @@
 
   </main>
 
+  <script src="scripts/incluir.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,18 +10,7 @@
 </head>
 <body>
 
-  <header>
-    <h1>SkyLog - Um olhar pousado no céu</h1>
-    <nav id="menu-tempo">
-      <a href="index.html">Ao vivo</a>
-      <a href="hora.html">Hora</a>
-      <button>Dia</button>
-      <button>Semana</button>
-      <button>Mês</button>
-      <button>Ano</button>
-      <button>Global</button>
-    </nav>
-  </header>
+  <div data-include-html="header.html"></div>
 
   <main class="painel">
 
@@ -46,6 +35,7 @@
     </section>
   </main>
 
+  <script src="scripts/incluir.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="scripts/livescript.js"></script>
 </body>

--- a/docs/scripts/incluir.js
+++ b/docs/scripts/incluir.js
@@ -1,0 +1,15 @@
+function includeHTML() {
+  document.querySelectorAll('[data-include-html]').forEach(el => {
+    const file = el.getAttribute('data-include-html');
+    if (!file) return;
+    fetch(file)
+      .then(resp => resp.text())
+      .then(html => {
+        el.outerHTML = html;
+      })
+      .catch(err => {
+        console.error('Erro ao incluir', file, err);
+      });
+  });
+}
+window.addEventListener('DOMContentLoaded', includeHTML);


### PR DESCRIPTION
## Summary
- move menu to `docs/header.html`
- dynamically load `header.html` with `scripts/incluir.js`
- use the shared menu in `index.html` and `hora.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877457de800832e95703680e488cc4e