### PR TITLE
Add daily data viewer

### DIFF
--- a/docs/dia.html
+++ b/docs/dia.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SkyLog - Um olhar pousado no céu</title>
+  <link rel="stylesheet" href="styles/style.css" />
+  <link
+    rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""/>
+</head>
+<body>
+
+  <div data-include-html="header.html"></div>
+
+  <main class="painel">
+
+    <!-- Rankings à esquerda -->
+    <div id="coluna-lateral">
+      <nav id="navegacao-dias">
+        <button id="dia-anterior">Dia anterior</button>
+        <button id="dia-seguinte">Dia seguinte</button>
+      </nav>
+      <div id="painel-ultimo-dia">
+        <h2>Neste dia</h2>
+        <p id="resumo-ultimo-dia"></p>
+      </div>
+
+      <div id="top-paises">
+        <h2>Top Países</h2>
+        <ul id="top-paises-lista"></ul>
+      </div>
+
+      <div id="top-companhias">
+        <h2>Top Companhias</h2>
+        <ul id="top-companhias-lista"></ul>
+      </div>
+    </div>
+
+    <!-- Mapa no centro -->
+    <section id="rotas">
+      <h2>Mapa de rotas</h2>
+      <div id="mapa">[Mapa de rotas]</div>
+    </section>
+
+    <!-- Avistamentos à direita -->
+    <section id="ultima-hora">
+      <h2>Avistamentos</h2>
+      <ul id="ultima-hora-lista"></ul>
+    </section>
+
+  </main>
+
+  <script src="scripts/incluir.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin=""></script>
+  <script src="scripts/painel_dia.js"></script>
+</body>
+</html>

--- a/docs/header.html
+++ b/docs/header.html
@@ -3,7 +3,7 @@
   <nav id="menu-tempo">
     <a href="index.html">Ao vivo</a>
     <a href="hora.html">Hora</a>
-    <button>Dia</button>
+    <a href="dia.html">Dia</a>
     <button>Semana</button>
     <button>Mês</button>
     <button>Ano</button>

--- a/docs/scripts/painel_dia.js
+++ b/docs/scripts/painel_dia.js
@@ -1,0 +1,220 @@
+
+async function carregarPainelDia() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const diaParam = params.get("d");
+    const ficheiro = diaParam
+      ? `arquivo/${diaParam}.json`
+      : `arquivo/ultimo-dia.json`;
+    const resp = await fetch(ficheiro);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const dados = await resp.json();
+
+    const bandeiras = {};
+    dados.top_paises.forEach(p => {
+      bandeiras[p.pais] = p.bandeira;
+    });
+
+    function capitalizar(str) {
+      return str
+        .toLowerCase()
+        .split(" ")
+        .map(p =>
+          p
+            .split("-")
+            .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+            .join("-")
+        )
+        .join(" ");
+    }
+
+    function calcBearing(lat1, lon1, lat2, lon2) {
+      const toRad = d => (d * Math.PI) / 180;
+      const dLon = toRad(lon2 - lon1);
+      const y = Math.sin(dLon) * Math.cos(toRad(lat2));
+      const x =
+        Math.cos(toRad(lat1)) * Math.sin(toRad(lat2)) -
+        Math.sin(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(dLon);
+      return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+    }
+
+    function formatLabel(date) {
+      const yyyy = date.getFullYear();
+      const mm = String(date.getMonth() + 1).padStart(2, "0");
+      const dd = String(date.getDate()).padStart(2, "0");
+      return `${yyyy}-${mm}-${dd}`;
+    }
+    const currentLabel = formatLabel(new Date(dados.voos_dia[0].hora));
+    const baseLabel = diaParam || currentLabel;
+    const baseDate = new Date(baseLabel);
+
+    const prevLabel = formatLabel(new Date(baseDate.getTime() - 24 * 3600 * 1000));
+    const nextLabel = formatLabel(new Date(baseDate.getTime() + 24 * 3600 * 1000));
+
+    const btnPrev = document.getElementById("dia-anterior");
+    if (btnPrev) btnPrev.onclick = () => {
+      window.location.search = "?d=" + prevLabel;
+    };
+
+    const btnNext = document.getElementById("dia-seguinte");
+    if (btnNext) {
+      if (diaParam) {
+        btnNext.onclick = async () => {
+          if (nextLabel === currentLabel) {
+            window.location.search = "";
+            return;
+          }
+          try {
+            const resp = await fetch(`arquivo/${nextLabel}.json`, { method: "HEAD" });
+            if (resp.ok) {
+              window.location.search = "?d=" + nextLabel;
+            } else {
+              window.location.search = "";
+            }
+          } catch {
+            window.location.search = "";
+          }
+
+        };
+      } else {
+        btnNext.disabled = true;
+      }
+    }
+
+    const ulHora = document.getElementById("ultima-hora-lista");
+    dados.voos_dia.forEach(v => {
+      const hm = v.hora.slice(11, 16).replace(":", "h") + "m";
+
+      const altM = v.alt ? Math.round(parseFloat(v.alt) * 0.3048) : null;
+      const velK = v.vel ? Math.round(parseFloat(v.vel) * 1.852) : null;
+
+      const localTxt = v.local ? `sobre ${capitalizar(v.local)} ` : "";
+      const bandeira = v.bandeira ? v.bandeira + " " : "";
+
+      ulHora.innerHTML += `
+        <li>
+          <strong>${v.chamada || v.hex}</strong>: ${v.cia || ""}, ${bandeira}${v.pais}
+          <ul>${v.origem ? `<strong>Origem:</strong> ${v.origem}` : ""}</ul>
+          <ul>${v.destino ? `<strong>Destino:</strong> ${v.destino}` : ""}</ul>
+          <ul>${altM !== null ? `<strong>Altitude:</strong> ${altM} metros` : ""}</ul>
+          <ul>${velK !== null ? `<strong>Velocidade:</strong> ${velK} km/h` : ""}</ul>
+          <ul>Avistado ${localTxt}às ${hm}${v.dist ? ` a ${v.dist} km de distância` : ""}</ul>
+        </li>`;
+    });
+
+    const ulPaises = document.getElementById("top-paises-lista");
+    dados.top_paises.forEach(p => {
+      ulPaises.innerHTML += `<li>${p.bandeira || ""} <strong>${p.pais}</strong>: ${p.total} aeronaves</li>`;
+    });
+
+    // resumo "Do dia"
+    const resumoEl = document.getElementById("resumo-ultimo-dia");
+    if (resumoEl) {
+      const total = dados.voos_dia.length;
+      const paisesSet = new Set();
+      const ciasSet = new Set();
+      let maxDist = -Infinity;
+      let maxLoc = "";
+      let minDist = Infinity;
+      let minLoc = "";
+      let semLoc = 0;
+        dados.voos_dia.forEach(v => {
+          if (v.pais) paisesSet.add(v.pais);
+          if (v.cia) ciasSet.add(v.cia);
+          const dist = parseFloat(v.dist);
+          if (isNaN(dist)) {
+            semLoc += 1;
+            return;
+          }
+          if (dist > maxDist) {
+            maxDist = dist;
+            maxLoc = v.local || "";
+          }
+          if (dist < minDist) {
+            minDist = dist;
+            minLoc = v.local || "";
+          }
+        });
+
+        resumoEl.innerHTML = `Neste dia foram detetadas ${total} aeronaves de ${paisesSet.size} países e ${ciasSet.size} companhias. A mais distante estava a ${maxDist}km sobre ${capitalizar(maxLoc)} e a mais próxima a ${minDist}km, sobre ${capitalizar(minLoc)}. Entre estes avistamentos, houve ${semLoc} aeronaves que não partilharam a sua localização.`;
+      }
+
+
+    const ulCias = document.getElementById("top-companhias-lista");
+    dados.top_companhias.forEach(c => {
+      ulCias.innerHTML += `<li><strong>${c.cia}</strong>: ${c.total} voos</li>`;
+    });
+
+    const initialZoom = 7;
+    const center = [39.6625, -7.7848];
+    const map = L.map("mapa", {
+      dragging: false,
+      minZoom: 7,
+      maxZoom: 18,
+      touchZoom: "center",
+    }).setView(center, initialZoom);
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap"
+    }).addTo(map);
+
+    const initialBounds = map.getBounds();
+    map.setMaxBounds(initialBounds);
+    map.options.maxBoundsViscosity = 1.0;
+    map.on("zoomend", () => {
+      if (map.getZoom() > initialZoom) {
+        map.dragging.enable();
+      } else {
+        map.dragging.disable();
+      }
+    });
+
+    function destPoint(lat, lon, brng, distKm) {
+      const R = 6371;
+      const toRad = d => (d * Math.PI) / 180;
+      const toDeg = d => (d * 180) / Math.PI;
+      const b = toRad(brng);
+      const d = distKm / R;
+      const lat1 = toRad(lat);
+      const lon1 = toRad(lon);
+      const lat2 = Math.asin(
+        Math.sin(lat1) * Math.cos(d) + Math.cos(lat1) * Math.sin(d) * Math.cos(b)
+      );
+      const lon2 =
+        lon1 +
+        Math.atan2(
+          Math.sin(b) * Math.sin(d) * Math.cos(lat1),
+          Math.cos(d) - Math.sin(lat1) * Math.sin(lat2)
+        );
+      return [toDeg(lat2), toDeg(lon2)];
+    }
+
+    function directionColor(bearing) {
+      const h = ((bearing % 360) + 360) % 360;
+      return `hsl(${h}, 80%, 45%)`;
+    }
+
+    function desenharSeta(inicio, fim, bearing, cor) {
+      L.polyline([inicio, fim], { color: cor, weight: 2 }).addTo(map);
+      const len = 5; // arrowhead length in km
+      const left = destPoint(fim[0], fim[1], bearing + 210, len);
+      const right = destPoint(fim[0], fim[1], bearing + 150, len);
+      L.polygon([left, fim, right], { color: cor, fillColor: cor, weight: 1 }).addTo(map);
+
+    }
+
+    dados.rotas.forEach(r => {
+      if (!r.de || !r.para) return;
+      const ini = [r.de[0], r.de[1]];
+      const fim = [r.para[0], r.para[1]];
+      const bearing = calcBearing(ini[0], ini[1], fim[0], fim[1]);
+      const cor = directionColor(bearing);
+      desenharSeta(ini, fim, bearing, cor);
+
+    });
+  } catch (e) {
+    console.error("Erro ao carregar painel:", e);
+  }
+}
+
+carregarPainelDia();

--- a/scripts/preparar_dia.py
+++ b/scripts/preparar_dia.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import os
+import json
+import csv
+import urllib.request
+import urllib.parse
+from math import radians, cos, sin, asin, sqrt
+from collections import defaultdict
+from typing import Any, Dict
+
+# Coordenadas da estação
+ESTACAO_LAT = 39.74759200010467
+ESTACAO_LON = -8.936510104648143
+
+
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371.0
+    lat1, lon1, lat2, lon2 = map(radians, [lat1, lon1, lat2, lon2])
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    c = 2 * asin(sqrt(a))
+    return round(R * c, 1)
+
+
+def carregar_json(caminho: Path):
+    with caminho.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def carregar_rotas(caminho: Path) -> Dict[str, Dict[str, Any]]:
+    """Carrega o cache de rotas do disco, se existir."""
+    if not caminho.exists():
+        return {}
+    try:
+        with caminho.open(encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return {}
+
+
+def gravar_rotas(caminho: Path, rotas: Dict[str, Dict[str, Any]]) -> None:
+    """Grava o cache de rotas para ficheiro."""
+    try:
+        caminho.parent.mkdir(parents=True, exist_ok=True)
+        with caminho.open("w", encoding="utf-8") as f:
+            json.dump(rotas, f, ensure_ascii=False, indent=2)
+    except Exception:
+        pass
+
+
+def hex_para_info_pais(hexcode: str, ranges: list[dict]):
+    try:
+        valor = int(hexcode, 16)
+        for entrada in ranges:
+            inicio = int(entrada["start"], 16)
+            fim = int(entrada["end"], 16)
+            if inicio <= valor <= fim:
+                return (
+                    entrada.get("country", "Desconhecido"),
+                    entrada.get("bandeira", ""),
+                )
+    except Exception:
+        pass
+    return "Desconhecido", ""
+
+
+def encontrar_local(lat: float, lon: float, features: list[dict]):
+    """Devolve o município mais próximo das coordenadas indicadas."""
+    melhor = None
+    melhor_dist = None
+    for feat in features:
+        nome = feat.get("properties", {}).get("nome") or feat.get("properties", {}).get(
+            "name"
+        )
+        try:
+            flon, flat = feat["geometry"]["coordinates"]
+        except Exception:
+            continue
+        d = haversine(lat, lon, flat, flon)
+        if melhor_dist is None or d < melhor_dist:
+            melhor_dist = d
+            melhor = nome
+    return melhor
+
+
+def _obter_nome_aeroporto(icao: str) -> str | None:
+    """Devolve o nome do aeroporto a partir do código ICAO."""
+    try:
+        url = "https://opensky-network.org/api/airports?icao=" + urllib.parse.quote(
+            icao
+        )
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            dados = json.loads(resp.read().decode())
+        return dados.get("name")
+    except Exception:
+        return None
+
+
+def _obter_rota_opensky(callsign: str) -> tuple[str | None, str | None]:
+    """Tenta obter a rota usando a API do OpenSky."""
+    url = "https://opensky-network.org/api/routes?callsign=" + urllib.parse.quote(
+        callsign
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            dados = json.loads(resp.read().decode())
+        rota = dados.get("route")
+        if rota and len(rota) >= 2:
+            origem = _obter_nome_aeroporto(rota[0])
+            destino = _obter_nome_aeroporto(rota[-1])
+            return origem, destino
+    except Exception:
+        pass
+    return None, None
+
+
+def _obter_rota_adsb(
+    callsign: str, lat: float, lon: float
+) -> tuple[str | None, str | None]:
+    """Tenta obter a rota usando a API do adsb.im.
+
+    Sempre que possível devolve "Cidade, PAÍS" para os aeroportos de origem
+    e destino.
+    """
+    url = "https://adsb.im/api/0/routeset"
+    payload = {
+        "planes": [
+            {
+                "callsign": callsign,
+                "lat": lat,
+                "lng": lon,
+            }
+        ]
+    }
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            dados = json.loads(resp.read().decode())
+        if isinstance(dados, list) and dados:
+            info = dados[0]
+            airports = info.get("_airports")
+            if airports and len(airports) >= 2:
+
+                def fmt(ap):
+                    if not isinstance(ap, dict):
+                        return None
+                    cidade = ap.get("location")
+                    pais = ap.get("countryiso2") or ap.get("country")
+                    return f"{cidade}, {pais}" if cidade and pais else None
+
+                origem = fmt(airports[0])
+                destino = fmt(airports[-1])
+                if origem or destino:
+                    return origem, destino
+
+            codes = info.get("airport_codes")
+            if codes and "-" in codes:
+                origem_icao, destino_icao = codes.split("-", 1)
+                origem = _obter_nome_aeroporto(origem_icao)
+                destino = _obter_nome_aeroporto(destino_icao)
+                return origem, destino
+
+    except Exception:
+        pass
+    return None, None
+
+
+def obter_rota(
+    callsign: str, lat: float | None, lon: float | None
+) -> tuple[str | None, str | None]:
+    """Obtém a rota de um voo usando adsb.im com fallback no OpenSky."""
+    origem = destino = None
+    if lat is not None and lon is not None:
+        origem, destino = _obter_rota_adsb(callsign, lat, lon)
+    if origem is None or destino is None:
+        alt_origem, alt_destino = _obter_rota_opensky(callsign)
+        origem = origem or alt_origem
+        destino = destino or alt_destino
+    return origem, destino
+
+
+def main() -> None:
+    base_dir = Path(os.environ.get("BASE_DIR", Path(__file__).resolve().parent.parent))
+    dir_csv = base_dir / "dados" / "diarios"
+    icao_ranges_path = base_dir / "dados" / "icao_ranges.json"
+    companhias_path = base_dir / "dados" / "companhias.json"
+    geo_path = base_dir / "dados" / "geo" / "ContinenteConcelhos.geojson"
+
+    icao_ranges = carregar_json(icao_ranges_path)
+    companhias_info = carregar_json(companhias_path)
+    rotas_cache_path = base_dir / "dados" / "rotas.json"
+    rotas_persistidas = carregar_rotas(rotas_cache_path)
+    rotas_alteradas = False
+    try:
+        geo_dados = carregar_json(geo_path)["features"]
+    except FileNotFoundError:
+        geo_dados = []
+
+    ficheiros = sorted(dir_csv.glob("*.csv"))
+    if len(ficheiros) < 2:
+        raise FileNotFoundError(
+            "Pelo menos dois ficheiros CSV são necessários em dados/diarios"
+        )
+
+    ultimo_csv = ficheiros[-2]
+
+    registos = []
+    companhias = defaultdict(int)
+    paises = defaultdict(int)
+    rotas_raw = {}
+    melhores_linhas = {}
+    rota_cache = {}
+
+    with ultimo_csv.open(encoding="utf-8") as f:
+        leitor = csv.DictReader(f)
+        for linha in leitor:
+            chamada = linha["flight"].strip()
+            hexcode = linha["hex"].strip()
+            voo_id = hexcode or chamada
+            if not voo_id:
+                continue
+
+            campos_check = [
+                "flight",
+                "alt_baro",
+                "gs",
+                "track",
+                "lat",
+                "lon",
+                "seen",
+                "squawk",
+                "category",
+            ]
+            score = sum(1 for c in campos_check if linha.get(c))
+
+            atual = melhores_linhas.get(voo_id)
+            if not atual or score > atual["score"]:
+                melhores_linhas[voo_id] = {"score": score, "linha": linha}
+
+            lat = linha.get("lat", "").strip()
+            lon = linha.get("lon", "").strip()
+            if lat and lon:
+                try:
+                    latf = float(lat)
+                    lonf = float(lon)
+                except ValueError:
+                    continue
+                info = rotas_raw.get(voo_id)
+                if not info:
+                    rotas_raw[voo_id] = {
+                        "de": [latf, lonf],
+                        "para": [latf, lonf],
+                    }
+                else:
+                    info["para"] = [latf, lonf]
+
+    for info in melhores_linhas.values():
+        linha = info["linha"]
+        chamada = linha["flight"].strip()
+        hexcode = linha["hex"].strip()
+        companhia = chamada[:3] if len(chamada) >= 3 else ""
+        companhia_nome = companhias_info.get(companhia, {}).get("nome", companhia)
+        alt = linha.get("alt_baro", "").strip()
+        vel = linha.get("gs", "").strip()
+        hora = linha["timestamp"][:16]
+
+        local = None
+        try:
+            lat = float(linha["lat"])
+            lon = float(linha["lon"])
+            dist = haversine(ESTACAO_LAT, ESTACAO_LON, lat, lon)
+            local = encontrar_local(lat, lon, geo_dados) if geo_dados else None
+        except Exception:
+            dist = ""
+
+        if not alt and not vel and not dist:
+            continue
+
+        pais, bandeira = hex_para_info_pais(hexcode, icao_ranges)
+
+        origem = destino = None
+        if chamada:
+            info_persistida = rotas_persistidas.get(chamada)
+            if info_persistida:
+                origem = info_persistida.get("origem")
+                destino = info_persistida.get("destino")
+
+            if origem is None or destino is None:
+                rota = rota_cache.get(chamada)
+                if rota is None:
+                    rota_cache[chamada] = obter_rota(chamada, lat, lon)
+                nova_origem, nova_destino = rota_cache.get(chamada, (None, None))
+                origem = origem or nova_origem
+                destino = destino or nova_destino
+
+            if chamada not in rotas_persistidas and (origem or destino):
+                rotas_persistidas[chamada] = {
+                    "origem": origem,
+                    "destino": destino,
+                }
+                rotas_alteradas = True
+            elif info_persistida and (
+                origem != info_persistida.get("origem")
+                or destino != info_persistida.get("destino")
+            ):
+                rotas_persistidas[chamada] = {
+                    "origem": origem,
+                    "destino": destino,
+                }
+                rotas_alteradas = True
+
+        if companhia:
+            companhias[companhia] += 1
+        if pais:
+            paises[(pais, bandeira)] += 1
+
+        registos.append(
+            {
+                "hex": hexcode,
+                "chamada": chamada,
+                "cia": companhia_nome,
+                "pais": pais,
+                "bandeira": bandeira,
+                "local": local,
+                "origem": origem,
+                "destino": destino,
+                "alt": alt,
+                "vel": vel,
+                "dist": dist,
+                "hora": hora,
+            }
+        )
+
+    voos_dia = sorted(registos, key=lambda x: x["hora"], reverse=True)
+
+    top_paises = sorted(paises.items(), key=lambda x: x[1], reverse=True)[:10]
+    top_companhias = sorted(companhias.items(), key=lambda x: x[1], reverse=True)[:10]
+
+    top_paises_legiveis = [
+        {"pais": chave[0], "bandeira": chave[1], "total": total}
+        for chave, total in top_paises
+    ]
+    top_companhias_legiveis = [
+        {"cia": companhias_info.get(c, {}).get("nome", c), "total": t}
+        for c, t in top_companhias
+    ]
+
+    rotas = []
+    for reg in registos:
+        vid = reg["hex"] or reg["chamada"]
+        pos = rotas_raw.get(vid)
+        if not pos:
+            continue
+        rota = {
+            "hex": reg["hex"],
+            "chamada": reg["chamada"],
+            "de": pos.get("de"),
+            "para": pos.get("para"),
+        }
+        alt = reg.get("alt")
+        if alt:
+            rota["alt"] = alt
+        rotas.append(rota)
+
+    saida = {
+        "voos_dia": voos_dia,
+        "top_paises": top_paises_legiveis,
+        "top_companhias": top_companhias_legiveis,
+        "rotas": rotas,
+    }
+
+    dia_label = voos_dia[0]["hora"][:10]
+    output_dir = base_dir / "docs" / "arquivo"
+    output_path = output_dir / f"{dia_label}.json"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(saida, f, ensure_ascii=False, indent=2)
+
+    latest_path = output_dir / "ultimo-dia.json"
+    with latest_path.open("w", encoding="utf-8") as f:
+        json.dump(saida, f, ensure_ascii=False, indent=2)
+
+    if rotas_alteradas:
+        gravar_rotas(rotas_cache_path, rotas_persistidas)
+
+    print(f"Ficheiro gerado: {output_path.name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate daily panel data from `dados/diarios`
- link new page in site header
- add HTML and JS to display daily stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68774fabc980832e85ae0f3576eec428