### PR TITLE
Atualiza painel de voos

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,16 +15,16 @@
   <main class="painel">
 
         <div id="coluna-lateral">
+        <div id="painel-mais-proximo">
+          <h2>Mais próximo</h2>
+          <div id="mais-proximo">Aguarde...</div>
+        </div>
+
         <div id="painel-ultima-hora">
           <h2>Neste momento</h2>
           <p>Esta página representa a atividade de aeronaves detetadas neste momento. Depende de vários fatores e da ligação de várias peças para que tudo se mantenha funcional.</p>
           <p>Se não estiver a funcionar em dado momento, aí está a razão: uma das peças falhou. :)</p>
           <p>Work in progress. To do.</p>
-        </div>
-
-        <div id="painel-mais-proximo">
-          <h2>Mais próximo</h2>
-          <div id="mais-proximo">Aguarde...</div>
         </div>
 
       </div>

--- a/docs/scripts/livescript.js
+++ b/docs/scripts/livescript.js
@@ -120,12 +120,15 @@ function atualizarPainelMaisProximo(ac, dist) {
       .then(j => {
         const p = j.photos && j.photos[0];
         if (p) {
-          fotoCache[ac.hex] = {
-            url: p.thumbnail_large,
-            link: p.link,
-            photographer: p.photographer
-          };
-          atualizarPainelMaisProximo(ac, dist);
+          const thumb = p.thumbnail_large || p.thumbail_large;
+          if (thumb) {
+            fotoCache[ac.hex] = {
+              url: thumb,
+              link: p.link,
+              photographer: p.photographer
+            };
+            atualizarPainelMaisProximo(ac, dist);
+          }
         }
       })
       .catch(() => {});


### PR DESCRIPTION
## Summary
- move painél "Mais próximo" para o topo
- exibir miniatura do avião mesmo se o campo vier como `thumbail_large`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d063b2d0832eb33f0f35554b3fc9