### PR TITLE
Fix photo rendering

### DIFF
--- a/docs/scripts/livescript.js
+++ b/docs/scripts/livescript.js
@@ -120,7 +120,8 @@ function atualizarPainelMaisProximo(ac, dist) {
       .then(j => {
         const p = j.photos && j.photos[0];
         if (p) {
-          const thumb = p.thumbnail_large || p.thumbail_large;
+          const thumb = (p.thumbnail_large && p.thumbnail_large.src) ||
+                        (p.thumbnail && p.thumbnail.src);
           if (thumb) {
             fotoCache[ac.hex] = {
               url: thumb,
@@ -135,13 +136,13 @@ function atualizarPainelMaisProximo(ac, dist) {
   }
 
   painelProximo.innerHTML = `
+    ${fotoHtml}
     <p><strong>${info}</strong> (${ac.hex.toUpperCase()})</p>
     <ul>${altM !== null ? `<strong>Altitude:</strong> ${altM} m` : ''}</ul>
     <ul>${vel !== null ? `<strong>Velocidade:</strong> ${vel} km/h` : ''}</ul>
     <ul><strong>Rumo:</strong> ${heading.toFixed(0)}º</ul>
     <ul><strong>Distância:</strong> ${dist.toFixed(1)} km</ul>
     <ul>Atualizado às ${hora}</ul>
-    ${fotoHtml}
   `;
   ultimoProximoHex = ac.hex;
 }

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -200,7 +200,7 @@ main.painel {
 #painel-mais-proximo img {
   width: 100%;
   border-radius: 4px;
-  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 


### PR DESCRIPTION
## Summary
- display the plane photo on top of the 'Mais próximo' panel
- use the correct photo URL from the Planespotters API
- tweak CSS margin for plane photo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d254e8c0832ebc9584d78c95d249