### PR TITLE
Make header menu responsive

### DIFF
--- a/docs/dia.html
+++ b/docs/dia.html
@@ -58,9 +58,10 @@
   </main>
 
   <script src="scripts/incluir.js"></script>
+  <script src="scripts/menu.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""></script>
   <script src="scripts/painel_dia.js"></script>
-</body>
+  </body>
 </html>

--- a/docs/header.html
+++ b/docs/header.html
@@ -1,5 +1,6 @@
 <header>
   <h1>SkyLog - Um olhar pousado no céu</h1>
+  <button id="menu-toggle" aria-label="Abrir menu">&#9776;</button>
   <nav id="menu-tempo">
     <a href="index.html">Ao vivo</a>
     <a href="hora.html">Hora</a>

--- a/docs/hora.html
+++ b/docs/hora.html
@@ -53,9 +53,10 @@
   </main>
 
   <script src="scripts/incluir.js"></script>
+  <script src="scripts/menu.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""></script>
   <script src="scripts/painel.js"></script>
-</body>
+  </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,8 @@
   </main>
 
   <script src="scripts/incluir.js"></script>
+  <script src="scripts/menu.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="scripts/livescript.js"></script>
-</body>
+  </body>
 </html>

--- a/docs/scripts/menu.js
+++ b/docs/scripts/menu.js
@@ -1,0 +1,13 @@
+function setupMenu() {
+  const toggle = document.getElementById('menu-toggle');
+  const menu = document.getElementById('menu-tempo');
+  if (!toggle || !menu) {
+    // header may not be loaded yet, try again shortly
+    return setTimeout(setupMenu, 100);
+  }
+  toggle.addEventListener('click', () => {
+    menu.classList.toggle('open');
+  });
+}
+
+document.addEventListener('DOMContentLoaded', setupMenu);

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -41,6 +41,18 @@ header h1 {
   background: #0277bd;
 }
 
+/* Botão do menu hamburguer */
+#menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 2rem;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
+}
+
 /* Navegação entre horas */
 #navegacao-horas {
   display: flex;
@@ -246,4 +258,21 @@ canvas {
   display: block;
   margin-top: 1rem;
   border-radius: 6px;
+}
+
+@media (max-width: 700px) {
+  #menu-tempo {
+    display: none;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  #menu-tempo.open {
+    display: flex;
+  }
+  #menu-toggle {
+    display: block;
+  }
+  header {
+    position: relative;
+  }
 }


### PR DESCRIPTION
## Summary
- turn navigation header into a hamburger menu on mobile
- add menu toggle script
- include new script on all pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d61ba0f8832e9b8312675270ee15