### PR TITLE
Remove halo from plane icons

### DIFF
--- a/docs/scripts/livescript.js
+++ b/docs/scripts/livescript.js
@@ -89,7 +89,8 @@ function createPlaneIcon(track = 0, altitude = 0, category = '') {
           -webkit-mask-repeat: no-repeat;
           -webkit-mask-size: contain;
           background-color: black;
-          filter: blur(1px);
+          /* removido o desfoque que criava uma aura involuntária */
+          filter: none;
           z-index: 0;
         "></div>
 


### PR DESCRIPTION
## Summary
- fix aura around plane icons by removing blur filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e8cdc4dc832e9a2c6cb7702a29a9