### PR TITLE
Fix plane icon aura in non-webkit browsers

### DIFF
--- a/docs/scripts/livescript.js
+++ b/docs/scripts/livescript.js
@@ -86,8 +86,11 @@ function createPlaneIcon(track = 0, altitude = 0, category = '') {
           top: 0; left: 0;
           width: ${size}px; height: ${size}px;
           -webkit-mask-image: url('${img}');
+          mask-image: url('${img}');
           -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
           -webkit-mask-size: contain;
+          mask-size: contain;
           background-color: black;
           /* removido o desfoque que criava uma aura involuntária */
           filter: none;
@@ -100,8 +103,11 @@ function createPlaneIcon(track = 0, altitude = 0, category = '') {
           top: 0; left: 0;
           width: ${size}px; height: ${size}px;
           -webkit-mask-image: url('${img}');
+          mask-image: url('${img}');
           -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
           -webkit-mask-size: contain;
+          mask-size: contain;
           background-color: ${color};
           z-index: 1;
         "></div>


### PR DESCRIPTION
## Summary
- ensure plane icon masking works outside of WebKit by adding unprefixed mask properties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f29cd090832e8b470bc689a2ccad