### PR TITLE
Ignore hex 490036 in live map

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,6 +43,9 @@
   <script src="scripts/incluir.js"></script>
   <script src="scripts/menu.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script>
+    window.BLACKLIST = ["490036"];
+  </script>
   <script src="scripts/livescript.js"></script>
   </body>
 </html>

--- a/docs/scripts/livescript.js
+++ b/docs/scripts/livescript.js
@@ -3,6 +3,9 @@ const API_URL = "https://skylog.franquinho.info/data/aircraft.json";
 const ESTACAO_LAT = 39.74759200010467;
 const ESTACAO_LON = -8.936510104648143;
 
+// Lista de hex codes a ignorar
+const HEX_BLACKLIST = new Set(window.BLACKLIST || []);
+
     const initialZoom = 7;
     const center = [39.6625, -7.7848];
     const map = L.map("mapa", {
@@ -183,6 +186,7 @@ function fetchAircraft() {
       let distProx = Infinity;
 
       (data.aircraft || []).forEach(ac => {
+        if (HEX_BLACKLIST.has(ac.hex)) return; // ignorar aeronaves banidas
         if (!ac.lat || !ac.lon || ac.seen > 60) return;
 
         const key = ac.hex;


### PR DESCRIPTION
## Summary
- add browser-side blacklist support
- ignore hex code `490036` via blacklist
- define the blacklist variable in `index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879614f99e0832e840fb5cc22d597aa