### PR TITLE
Fix plane icon coloring

### DIFF
--- a/docs/scripts/livescript.js
+++ b/docs/scripts/livescript.js
@@ -79,41 +79,25 @@ function createPlaneIcon(track = 0, altitude = 0, category = '') {
   const img = getImageByCategory(category);
   const size = 30;
 
+  const colorFilter = cssFilterFromColor(color);
+
   return L.divIcon({
     className: "plane-icon",
     html: `
       <div style="position: relative; width: ${size}px; height: ${size}px; transform: rotate(${track}deg);">
-        <!-- camada inferior (contorno preto) -->
-        <div style="
+        <img src="${img}" style="
           position: absolute;
           top: 0; left: 0;
           width: ${size}px; height: ${size}px;
-          -webkit-mask-image: url('${img}');
-          mask-image: url('${img}');
-          -webkit-mask-repeat: no-repeat;
-          mask-repeat: no-repeat;
-          -webkit-mask-size: contain;
-          mask-size: contain;
-          background-color: black;
-          /* removido o desfoque que criava uma aura involuntária */
-          filter: none;
           z-index: 0;
-        "></div>
-
-        <!-- camada superior (avião colorido) -->
-        <div style="
+        ">
+        <img src="${img}" style="
           position: absolute;
           top: 0; left: 0;
           width: ${size}px; height: ${size}px;
-          -webkit-mask-image: url('${img}');
-          mask-image: url('${img}');
-          -webkit-mask-repeat: no-repeat;
-          mask-repeat: no-repeat;
-          -webkit-mask-size: contain;
-          mask-size: contain;
-          background-color: ${color};
+          filter: ${colorFilter};
           z-index: 1;
-        "></div>
+        ">
       </div>
     `,
     iconSize: [size, size],


### PR DESCRIPTION
## Summary
- color plane icons without filling the whole square

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687963d8c014832e8d5e317d7c44abf6